### PR TITLE
Hi there, I've made some changes to your code.

### DIFF
--- a/utilities/config.json
+++ b/utilities/config.json
@@ -1,0 +1,3 @@
+{
+  "BASE_URL": "http://localhost:8080"
+}

--- a/utilities/todo_cli.py
+++ b/utilities/todo_cli.py
@@ -4,8 +4,28 @@ import argparse
 import json
 import sys
 import requests
+import os # For path manipulation if needed
 
-BASE_URL = "http://localhost:8080"
+CONFIG_FILE_PATH = os.path.join(os.path.dirname(__file__), 'config.json') # Example for co-located config
+# CONFIG_FILE_PATH = 'config.json' # Simpler path as they are in the same directory - THIS WAS THE BUG
+
+def load_config():
+    try:
+        with open(CONFIG_FILE_PATH, 'r') as f:
+            config = json.load(f)
+        return config["BASE_URL"]
+    # Error handling will be added in the next step as per instructions
+    except FileNotFoundError:
+        print(f"Error: Configuration file '{CONFIG_FILE_PATH}' not found.")
+        sys.exit(1)
+    except json.JSONDecodeError:
+        print(f"Error: Could not decode JSON from '{CONFIG_FILE_PATH}'.")
+        sys.exit(1)
+    except KeyError:
+        print(f"Error: 'BASE_URL' not found in '{CONFIG_FILE_PATH}'.")
+        sys.exit(1)
+
+BASE_URL = load_config()
 
 def handle_list_items():
     """Handles listing all items."""


### PR DESCRIPTION
I've refactored `utilities/todo_cli.py` to use a configuration file for the `BASE_URL` instead of a hardcoded value.

Now, the script will read the `BASE_URL` from `utilities/config.json`. This will make it easier for you to configure the target API endpoint.

Here's a summary of what I did:
- I added `utilities/config.json` to store the `BASE_URL`.
- I modified `todo_cli.py` to include a `load_config()` function. This function:
    - Reads `BASE_URL` from `config.json`.
    - Uses `os.path.join(os.path.dirname(__file__), 'config.json')` to reliably find the config file.
    - Includes error handling for scenarios like a missing config file, malformed JSON, or a missing `BASE_URL` key.
- All API calls now use the `BASE_URL` that's loaded from the configuration.
- I also confirmed that normal operation and error handling are working as expected.