### PR TITLE
Refactor: Replace REST Update API with OpenAPI implementation

### DIFF
--- a/handlers/item_handlers_test.go
+++ b/handlers/item_handlers_test.go
@@ -4,25 +4,25 @@ import (
 	"bytes"
 	"database/sql"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	stdruntime "runtime" // Standard runtime
 	"strconv"
 	"strings"
 	"testing"
-	"errors" // For custom error handler
-	"os"     // For os.ReadFile
 
 	"app/database"
-	"app/models" // Original model, still used for creating test data
 	"app/internal/generated/openapi" // Added for generated types & its local error types
+	"app/models"                     // Original model, still used for creating test data
 
 	"github.com/go-chi/chi/v5"
+	_ "github.com/mattn/go-sqlite3" // SQLite driver
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	_ "github.com/mattn/go-sqlite3"
 )
 
 // getProjectRootForHandlers uses standard runtime.
@@ -35,168 +35,73 @@ func getProjectRootForHandlers() string {
 func setupHandlerTestDB(t *testing.T) *sql.DB {
 	db, err := database.InitDB(":memory:")
 	require.NoError(t, err, "Failed to initialize test database for handlers")
-	return db
-}
 
-// setupTestRouter initializes a Chi router with the necessary handlers for testing.
-func setupTestRouter(db *sql.DB) *chi.Mux {
-	router := chi.NewRouter()
-	itemAPIServer := NewItemAPIServer(db)
-
-	openapi.HandlerWithOptions(itemAPIServer, openapi.ChiServerOptions{
-		BaseRouter: router,
-		ErrorHandlerFunc: func(w http.ResponseWriter, r *http.Request, err error) {
-			w.Header().Set("Content-Type", "application/json")
-			var status int
-			var e *openapi.InvalidParamFormatError // Use error type from the generated openapi package
-			if errors.As(err, &e) {
-				status = http.StatusBadRequest
-			} else {
-				status = http.StatusBadRequest
-			}
-			w.WriteHeader(status)
-			json.NewEncoder(w).Encode(openapi.Error{Error: err.Error()})
-		},
-	})
-
-	// router.Post("/items", CreateItemHandler(db)) // This handler was removed and is covered by OpenAPI
-	router.Get("/items", GetItemsHandler(db))
-	router.Put("/items/{id}", UpdateItemHandler(db))
-	router.Delete("/items/{id}", DeleteItemHandler(db))
-
-	return router
-}
-
-
-func TestCreateItemHandler(t *testing.T) {
-	db := setupHandlerTestDB(t)
-	defer db.Close()
-	router := setupTestRouter(db)
-
-	itemPayload := models.Item{
-		Name:        "Test Handler Item",
-		Description: "Description for handler test",
-		Priority:    1,
-	}
-	payloadBytes, err := json.Marshal(itemPayload)
-	require.NoError(t, err)
-
-	req, err := http.NewRequest(http.MethodPost, "/items", bytes.NewBuffer(payloadBytes))
-	require.NoError(t, err)
-	req.Header.Set("Content-Type", "application/json")
-
-	rr := httptest.NewRecorder()
-	router.ServeHTTP(rr, req)
-
-	assert.Equal(t, http.StatusCreated, rr.Code)
-	var createdItem models.Item
-	err = json.NewDecoder(rr.Body).Decode(&createdItem)
-	require.NoError(t, err)
-	assert.NotZero(t, createdItem.ID)
-	assert.Equal(t, itemPayload.Name, createdItem.Name)
-}
-
-func TestGetItemsHandler(t *testing.T) {
-	db := setupHandlerTestDB(t)
-	defer db.Close()
-	_, err := database.CreateItem(db, models.Item{Name: "Item1", Description: "Desc1", Priority: 1})
-	require.NoError(t, err)
-	_, err = database.CreateItem(db, models.Item{Name: "Item2", Description: "Desc2", Priority: 2})
-	require.NoError(t, err)
-	router := setupTestRouter(db)
-
-	req, err := http.NewRequest(http.MethodGet, "/items", nil)
-	require.NoError(t, err)
-	rr := httptest.NewRecorder()
-	router.ServeHTTP(rr, req)
-
-	assert.Equal(t, http.StatusOK, rr.Code)
-	var items []models.Item
-	err = json.NewDecoder(rr.Body).Decode(&items)
-	require.NoError(t, err)
-	assert.Len(t, items, 2)
-}
-
-func TestGetItemByIdHandler(t *testing.T) {
-	db := setupHandlerTestDB(t)
-	defer db.Close()
-	createdItemInput := models.Item{Name: "SpecificItem", Description: "Specific Description", Priority: 3}
-	createdID, err := database.CreateItem(db, createdItemInput)
-	require.NoError(t, err)
-	router := setupTestRouter(db)
-
-	t.Run("found", func(t *testing.T) {
-		reqPath := "/items/" + strconv.FormatInt(createdID, 10)
-		req, err := http.NewRequest(http.MethodGet, reqPath, nil)
-		require.NoError(t, err)
-		rr := httptest.NewRecorder()
-		router.ServeHTTP(rr, req)
-		assert.Equal(t, http.StatusOK, rr.Code)
-		var item openapi.Item
-		err = json.NewDecoder(rr.Body).Decode(&item)
-		require.NoError(t, err)
-		require.NotNil(t, item.Id)
-		assert.Equal(t, createdID, *item.Id)
-		assert.Equal(t, createdItemInput.Name, item.Name)
-		require.NotNil(t, item.Description)
-		assert.Equal(t, createdItemInput.Description, *item.Description)
-		assert.Equal(t, int32(createdItemInput.Priority), item.Priority)
-	})
-
-	t.Run("not found", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodGet, "/items/99999", nil)
-		require.NoError(t, err)
-		rr := httptest.NewRecorder()
-		router.ServeHTTP(rr, req)
-		assert.Equal(t, http.StatusNotFound, rr.Code)
-		var errResp openapi.Error
-		err = json.NewDecoder(rr.Body).Decode(&errResp)
-		require.NoError(t, err)
-		assert.Contains(t, errResp.Error, "Item not found")
-	})
-
-	t.Run("invalid id format", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodGet, "/items/abc", nil)
-		require.NoError(t, err)
-		rr := httptest.NewRecorder()
-		router.ServeHTTP(rr, req)
-		assert.Equal(t, http.StatusBadRequest, rr.Code)
-		var errResp openapi.Error
-		decodeErr := json.NewDecoder(rr.Body).Decode(&errResp)
-		require.NoError(t, decodeErr, "Failed to decode error response into openapi.Error for invalid id format")
-		assert.NotEmpty(t, errResp.Error)
-		assert.Contains(t, strings.ToLower(errResp.Error), "invalid format for parameter", "Error message should indicate invalid format for parameter")
-	})
-}
-
-// PtrString is a helper function to get a pointer to a string.
-// Useful for optional string fields in OpenAPI generated structs.
-func PtrString(s string) *string {
-	return &s
-}
-
-func TestCreateItemOpenAPI(t *testing.T) {
-	db := setupHandlerTestDB(t)
-	defer db.Close()
-
-	// Read and execute schema
-	// Adjust path if getProjectRootForHandlers() is not suitable or if tests are run from a different CWD.
-	// Assuming tests are run from the 'handlers' directory or project root where '../database/schema.sql' is valid.
+	// Apply schema
 	schemaPath := filepath.Join(getProjectRootForHandlers(), "database", "schema.sql")
 	schemaBytes, err := os.ReadFile(schemaPath)
 	require.NoError(t, err, "Failed to read schema.sql")
 	_, err = db.Exec(string(schemaBytes))
 	require.NoError(t, err, "Failed to execute schema on test database")
 
-	itemAPIServer := NewItemAPIServer(db) // Use the actual ItemAPIServer
-	router := chi.NewRouter()          // Create a new router for this specific test setup
+	return db
+}
 
-	// Register ONLY the OpenAPI handlers. This ensures that POST /items uses the openapi_handlers.CreateItem
+// setupTestRouter initializes a Chi router with the necessary handlers for testing.
+// This version is updated to only use OpenAPI handlers for Create, GetByID, and UpdateByID.
+func setupTestRouter(db *sql.DB) *chi.Mux {
+	router := chi.NewRouter()
+	itemAPIServer := NewItemAPIServer(db)
+
+	// Register OpenAPI handlers (includes POST /items, GET /items/{id}, PUT /items/{id})
 	openapi.HandlerWithOptions(itemAPIServer, openapi.ChiServerOptions{
 		BaseRouter: router,
-		ErrorHandlerFunc: func(w http.ResponseWriter, r *http.Request, err error) { // Optional: Custom error handler for tests
+		ErrorHandlerFunc: func(w http.ResponseWriter, r *http.Request, err error) {
 			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusBadRequest) // Default to 400 for test simplicity
+			status := http.StatusBadRequest // Default
+			var e *openapi.InvalidParamFormatError
+			if errors.As(err, &e) {
+				status = http.StatusBadRequest
+			} else if strings.Contains(err.Error(), "found") { // Simple check for "not found" type errors
+				status = http.StatusNotFound
+			}
+			// Add more specific error type checks if needed from oapi-codegen/runtime
+			w.WriteHeader(status)
+			json.NewEncoder(w).Encode(openapi.Error{Error: err.Error()})
+		},
+	})
+
+	// Register other non-OpenAPI routes (if any) that are still managed by old handlers
+	router.Get("/items", GetItemsHandler(db)) // For getting all items (assuming this is not OpenAPI yet)
+	// router.Put("/items/{id}", UpdateItemHandler(db)) // REMOVED - Now handled by OpenAPI
+	router.Delete("/items/{id}", DeleteItemHandler(db)) // Assuming this is not OpenAPI yet
+
+	return router
+}
+
+// PtrString is a helper function to get a pointer to a string.
+func PtrString(s string) *string {
+	return &s
+}
+
+// Helper to create an item directly in the DB for test setup
+func createTestItemDirectly(t *testing.T, db *sql.DB, item models.Item) models.Item {
+	id, err := database.CreateItem(db, item)
+	require.NoError(t, err)
+	item.ID = id
+	return item
+}
+
+func TestCreateItemOpenAPI(t *testing.T) {
+	db := setupHandlerTestDB(t) // This already applies schema
+	defer db.Close()
+
+	itemAPIServer := NewItemAPIServer(db)
+	router := chi.NewRouter()
+	openapi.HandlerWithOptions(itemAPIServer, openapi.ChiServerOptions{
+		BaseRouter: router,
+		ErrorHandlerFunc: func(w http.ResponseWriter, r *http.Request, err error) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
 			json.NewEncoder(w).Encode(openapi.Error{Error: "test error handler: " + err.Error()})
 		},
 	})
@@ -208,175 +113,368 @@ func TestCreateItemOpenAPI(t *testing.T) {
 		newItem := openapi.NewItem{
 			Name:        "Test Item via OpenAPI",
 			Priority:    10,
-			Description: PtrString("A description for OpenAPI test"), // Use local PtrString
+			Description: PtrString("A description for OpenAPI test"),
 		}
-		bodyBytes, err := json.Marshal(newItem)
-		require.NoError(t, err)
-
+		bodyBytes, _ := json.Marshal(newItem)
 		res, err := http.Post(ts.URL+"/items", "application/json", bytes.NewBuffer(bodyBytes))
 		require.NoError(t, err)
 		defer res.Body.Close()
-
-		require.Equal(t, http.StatusCreated, res.StatusCode, "Expected status 201 Created")
-
+		require.Equal(t, http.StatusCreated, res.StatusCode)
 		var createdItem openapi.Item
 		err = json.NewDecoder(res.Body).Decode(&createdItem)
-		require.NoError(t, err, "Failed to decode successful response")
-
+		require.NoError(t, err)
 		assert.Equal(t, newItem.Name, createdItem.Name)
 		assert.Equal(t, newItem.Priority, createdItem.Priority)
-		require.NotNil(t, newItem.Description, "Test setup error: newItem.Description should not be nil")
-		require.NotNil(t, createdItem.Description, "createdItem.Description should not be nil for this test case")
-		if createdItem.Description != nil && newItem.Description != nil { // Defensive check
-			assert.Equal(t, *newItem.Description, *createdItem.Description)
-		}
-		require.NotNil(t, createdItem.Id, "Created item ID should not be nil")
-		assert.True(t, *createdItem.Id > 0, "Created item ID should be positive")
+		assert.EqualValues(t, newItem.Description, createdItem.Description)
+		require.NotNil(t, createdItem.Id)
+		assert.True(t, *createdItem.Id > 0)
 	})
 
 	t.Run("Bad request via OpenAPI - missing name", func(t *testing.T) {
-		badItem := openapi.NewItem{
-			// Name is intentionally missing
-			Priority:    5,
-			Description: PtrString("Item with no name"), // Use local PtrString
-		}
-		bodyBytes, err := json.Marshal(badItem)
-		require.NoError(t, err)
-
+		badItem := openapi.NewItem{Priority: 5, Description: PtrString("Item with no name")}
+		bodyBytes, _ := json.Marshal(badItem)
 		res, err := http.Post(ts.URL+"/items", "application/json", bytes.NewBuffer(bodyBytes))
 		require.NoError(t, err)
 		defer res.Body.Close()
-
-		require.Equal(t, http.StatusBadRequest, res.StatusCode, "Expected status 400 Bad Request")
-
+		require.Equal(t, http.StatusBadRequest, res.StatusCode)
 		var errResp openapi.Error
-		err = json.NewDecoder(res.Body).Decode(&errResp)
-		require.NoError(t, err, "Failed to decode error response")
-
-		// The error message comes from the validation in handlers/openapi_handlers.go CreateItem
-		expectedErrorMsg := "Name is required"
-		assert.Contains(t, errResp.Error, expectedErrorMsg, "Error message mismatch")
+		_ = json.NewDecoder(res.Body).Decode(&errResp)
+		assert.Contains(t, errResp.Error, "Name is required")
 	})
 
 	t.Run("Bad request via OpenAPI - invalid priority", func(t *testing.T) {
-		badItem := openapi.NewItem{
-			Name:        "Item with bad priority",
-			Priority:    0, // Priority must be positive
-			Description: PtrString("A description"),
-		}
-		bodyBytes, err := json.Marshal(badItem)
-		require.NoError(t, err)
-
+		badItem := openapi.NewItem{Name: "Item with bad priority", Priority: 0, Description: PtrString("A description")}
+		bodyBytes, _ := json.Marshal(badItem)
 		res, err := http.Post(ts.URL+"/items", "application/json", bytes.NewBuffer(bodyBytes))
 		require.NoError(t, err)
 		defer res.Body.Close()
-
 		require.Equal(t, http.StatusBadRequest, res.StatusCode)
-
 		var errResp openapi.Error
-		err = json.NewDecoder(res.Body).Decode(&errResp)
-		require.NoError(t, err)
-		expectedErrorMsg := "Priority must be a positive integer"
-		assert.Contains(t, errResp.Error, expectedErrorMsg)
+		_ = json.NewDecoder(res.Body).Decode(&errResp)
+		assert.Contains(t, errResp.Error, "Priority must be a positive integer")
 	})
 
 	t.Run("Bad request via OpenAPI - malformed JSON", func(t *testing.T) {
-		malformedJSON := `{"name": "Test", "priority": 1, "description": "Test desc"` // Missing closing brace
-
+		malformedJSON := `{"name": "Test", "priority": 1, "description": "Test desc"`
 		res, err := http.Post(ts.URL+"/items", "application/json", strings.NewReader(malformedJSON))
 		require.NoError(t, err)
 		defer res.Body.Close()
-
 		require.Equal(t, http.StatusBadRequest, res.StatusCode)
-
 		var errResp openapi.Error
-		err = json.NewDecoder(res.Body).Decode(&errResp)
-		require.NoError(t, err, "Failed to decode malformed JSON error response")
-		// Error comes from json.NewDecoder in the handler
-		assert.Contains(t, errResp.Error, "Invalid request payload", "Expected error message for malformed JSON")
+		_ = json.NewDecoder(res.Body).Decode(&errResp)
+		assert.Contains(t, errResp.Error, "Invalid request payload")
 	})
 }
 
-func TestUpdateItemHandler(t *testing.T) {
+func TestGetItemsHandler(t *testing.T) { // Assuming this remains non-OpenAPI for now
 	db := setupHandlerTestDB(t)
 	defer db.Close()
-	initialItem := models.Item{Name: "InitialName", Description: "Initial Desc", Priority: 1}
-	initialID, err := database.CreateItem(db, initialItem)
-	require.NoError(t, err)
+	createTestItemDirectly(t, db, models.Item{Name: "Item1", Description: "Desc1", Priority: 1})
+	createTestItemDirectly(t, db, models.Item{Name: "Item2", Description: "Desc2", Priority: 2})
 	router := setupTestRouter(db)
 
-	updatePayload := models.Item{Name: "UpdatedName", Description: "Updated Desc", Priority: 2}
-	payloadBytes, _ := json.Marshal(updatePayload)
-	reqPath := "/items/" + strconv.FormatInt(initialID, 10)
-	req, err := http.NewRequest(http.MethodPut, reqPath, bytes.NewBuffer(payloadBytes))
-	require.NoError(t, err)
-	req.Header.Set("Content-Type", "application/json")
-
+	req, _ := http.NewRequest(http.MethodGet, "/items", nil)
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusOK, rr.Code)
-	var updatedItem models.Item
-	err = json.NewDecoder(rr.Body).Decode(&updatedItem)
+	var items []models.Item
+	err := json.NewDecoder(rr.Body).Decode(&items)
 	require.NoError(t, err)
-	assert.Equal(t, "UpdatedName", updatedItem.Name)
-	assert.Equal(t, initialID, updatedItem.ID)
+	assert.Len(t, items, 2)
 }
 
-func TestDeleteItemHandler(t *testing.T) {
+func TestGetItemByIdOpenAPI(t *testing.T) { // Renamed to avoid conflict if an old GetItemByIdHandler test existed
 	db := setupHandlerTestDB(t)
 	defer db.Close()
-	itemToDelete := models.Item{Name: "ToDelete", Description: "Delete Desc", Priority: 1}
-	initialID, err := database.CreateItem(db, itemToDelete)
-	require.NoError(t, err)
+	initialItem := createTestItemDirectly(t, db, models.Item{Name: "SpecificItem", Description: "Specific Description", Priority: 3})
+	router := setupTestRouter(db) // This router uses OpenAPI for /items/{id} GET
+
+	t.Run("found", func(t *testing.T) {
+		reqPath := "/items/" + strconv.FormatInt(initialItem.ID, 10)
+		req, _ := http.NewRequest(http.MethodGet, reqPath, nil)
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+
+		require.Equal(t, http.StatusOK, rr.Code)
+		var item openapi.Item
+		err := json.NewDecoder(rr.Body).Decode(&item)
+		require.NoError(t, err)
+		require.NotNil(t, item.Id)
+		assert.Equal(t, initialItem.ID, *item.Id)
+		assert.Equal(t, initialItem.Name, item.Name)
+		require.NotNil(t, item.Description)
+		assert.Equal(t, initialItem.Description, *item.Description)
+		assert.Equal(t, int32(initialItem.Priority), item.Priority)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "/items/99999", nil)
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusNotFound, rr.Code)
+		var errResp openapi.Error
+		err := json.NewDecoder(rr.Body).Decode(&errResp)
+		require.NoError(t, err)
+		assert.Contains(t, errResp.Error, "Item not found")
+	})
+
+	t.Run("invalid id format", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, "/items/abc", nil)
+		rr := httptest.NewRecorder()
+		router.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusBadRequest, rr.Code) // Error handler in setupTestRouter should catch this
+		var errResp openapi.Error
+		err := json.NewDecoder(rr.Body).Decode(&errResp)
+		require.NoError(t, err)
+		assert.Contains(t, strings.ToLower(errResp.Error), "invalid format for parameter id")
+	})
+}
+
+func TestUpdateItemOpenAPI(t *testing.T) {
+	db := setupHandlerTestDB(t) // This also applies the schema
+	defer db.Close()
+
+	router := setupTestRouter(db) // This router includes the OpenAPI PUT handler
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	// Pre-populate an item to update
+	initialItemModel := createTestItemDirectly(t, db, models.Item{Name: "Initial Item", Priority: 1, Description: "Initial Description"})
+
+	client := &http.Client{}
+
+	t.Run("Successful Update", func(t *testing.T) {
+		updatePayload := openapi.UpdateItem{
+			Name:        "Updated Item Name",
+			Priority:    5,
+			Description: PtrString("Updated Description"),
+		}
+		payloadBytes, _ := json.Marshal(updatePayload)
+		reqURL := fmt.Sprintf("%s/items/%d", ts.URL, initialItemModel.ID)
+		req, _ := http.NewRequest(http.MethodPut, reqURL, bytes.NewBuffer(payloadBytes))
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var updatedAPIItem openapi.Item
+		err = json.NewDecoder(resp.Body).Decode(&updatedAPIItem)
+		require.NoError(t, err)
+
+		assert.Equal(t, updatePayload.Name, updatedAPIItem.Name)
+		assert.Equal(t, updatePayload.Priority, updatedAPIItem.Priority)
+		require.NotNil(t, updatedAPIItem.Description)
+		assert.Equal(t, *updatePayload.Description, *updatedAPIItem.Description)
+		require.NotNil(t, updatedAPIItem.Id)
+		assert.Equal(t, initialItemModel.ID, *updatedAPIItem.Id)
+
+		// Verify in DB
+		dbItem, err := database.GetItem(db, initialItemModel.ID)
+		require.NoError(t, err)
+		assert.Equal(t, updatePayload.Name, dbItem.Name)
+		assert.Equal(t, int(updatePayload.Priority), dbItem.Priority)
+		assert.Equal(t, *updatePayload.Description, dbItem.Description)
+	})
+
+	t.Run("Successful Update with nil description", func(t *testing.T) {
+		// Create a new item for this specific test case to avoid interference
+		itemToUpdate := createTestItemDirectly(t, db, models.Item{Name: "Item For Nil Desc Update", Priority: 2, Description: "Existing Description"})
+
+		updatePayload := openapi.UpdateItem{
+			Name:        "Updated Name For Nil Desc",
+			Priority:    int32(itemToUpdate.Priority), // Keep priority same or change, doesn't matter much for this test
+			Description: nil,                   // Explicitly set description to nil
+		}
+		payloadBytes, _ := json.Marshal(updatePayload)
+		reqURL := fmt.Sprintf("%s/items/%d", ts.URL, itemToUpdate.ID)
+		req, _ := http.NewRequest(http.MethodPut, reqURL, bytes.NewBuffer(payloadBytes))
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		var respItem openapi.Item
+		err = json.NewDecoder(resp.Body).Decode(&respItem)
+		require.NoError(t, err)
+
+		assert.Equal(t, updatePayload.Name, respItem.Name)
+		// In the handler, if requestBody.Description is nil, dbItem.Description becomes ""
+		// Then, when fetching for response, responseItem.Description becomes &""
+		require.NotNil(t, respItem.Description, "Description should be non-nil pointer to empty string")
+		assert.Equal(t, "", *respItem.Description, "Description in response should be empty string")
+
+
+		// Verify in DB
+		dbItem, err := database.GetItem(db, itemToUpdate.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "", dbItem.Description, "Description in DB should be empty string")
+	})
+
+	t.Run("Successful Update with empty string description", func(t *testing.T) {
+		itemToUpdate := createTestItemDirectly(t, db, models.Item{Name: "Item For Empty Desc Update", Priority: 3, Description: "Non-empty description"})
+
+		updatePayload := openapi.UpdateItem{
+			Name:        "Updated Name For Empty Desc",
+			Priority:    int32(itemToUpdate.Priority),
+			Description: PtrString(""), // Explicitly set description to pointer to empty string
+		}
+		payloadBytes, _ := json.Marshal(updatePayload)
+		reqURL := fmt.Sprintf("%s/items/%d", ts.URL, itemToUpdate.ID)
+		req, _ := http.NewRequest(http.MethodPut, reqURL, bytes.NewBuffer(payloadBytes))
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		var respItem openapi.Item
+		err = json.NewDecoder(resp.Body).Decode(&respItem)
+		require.NoError(t, err)
+
+		assert.Equal(t, updatePayload.Name, respItem.Name)
+		require.NotNil(t, respItem.Description)
+		assert.Equal(t, "", *respItem.Description)
+
+		// Verify in DB
+		dbItem, err := database.GetItem(db, itemToUpdate.ID)
+		require.NoError(t, err)
+		assert.Equal(t, "", dbItem.Description)
+	})
+
+
+	t.Run("Item Not Found (404)", func(t *testing.T) {
+		updatePayload := openapi.UpdateItem{Name: "Any Name", Priority: 1}
+		payloadBytes, _ := json.Marshal(updatePayload)
+		reqURL := fmt.Sprintf("%s/items/999999", ts.URL) // Non-existent ID
+		req, _ := http.NewRequest(http.MethodPut, reqURL, bytes.NewBuffer(payloadBytes))
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusNotFound, resp.StatusCode)
+		var errResp openapi.Error
+		err = json.NewDecoder(resp.Body).Decode(&errResp)
+		require.NoError(t, err)
+		assert.Contains(t, errResp.Error, "Item not found")
+	})
+
+	t.Run("Invalid Payload - Missing Name (400)", func(t *testing.T) {
+		updatePayload := openapi.UpdateItem{Priority: 1} // Name is missing
+		payloadBytes, _ := json.Marshal(updatePayload)
+		reqURL := fmt.Sprintf("%s/items/%d", ts.URL, initialItemModel.ID)
+		req, _ := http.NewRequest(http.MethodPut, reqURL, bytes.NewBuffer(payloadBytes))
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		var errResp openapi.Error
+		err = json.NewDecoder(resp.Body).Decode(&errResp)
+		require.NoError(t, err)
+		assert.Contains(t, errResp.Error, "Name is required")
+	})
+
+	t.Run("Invalid Payload - Invalid Priority (400)", func(t *testing.T) {
+		updatePayload := openapi.UpdateItem{Name: "Test Name", Priority: 0} // Invalid priority
+		payloadBytes, _ := json.Marshal(updatePayload)
+		reqURL := fmt.Sprintf("%s/items/%d", ts.URL, initialItemModel.ID)
+		req, _ := http.NewRequest(http.MethodPut, reqURL, bytes.NewBuffer(payloadBytes))
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		var errResp openapi.Error
+		err = json.NewDecoder(resp.Body).Decode(&errResp)
+		require.NoError(t, err)
+		assert.Contains(t, errResp.Error, "Priority must be a positive integer")
+	})
+
+	t.Run("Invalid Item ID in Path (not an integer)", func(t *testing.T) {
+		updatePayload := openapi.UpdateItem{Name: "Any Name", Priority: 1}
+		payloadBytes, _ := json.Marshal(updatePayload)
+		reqURL := fmt.Sprintf("%s/items/notaninteger", ts.URL)
+		req, _ := http.NewRequest(http.MethodPut, reqURL, bytes.NewBuffer(payloadBytes))
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		// This error is caught by the custom ErrorHandlerFunc in setupTestRouter,
+		// which wraps the oapi-codegen runtime's parameter binding error.
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		var errResp openapi.Error
+		err = json.NewDecoder(resp.Body).Decode(&errResp)
+		require.NoError(t, err)
+		assert.Contains(t, strings.ToLower(errResp.Error), "invalid format for parameter id")
+	})
+
+	t.Run("Malformed JSON payload", func(t *testing.T) {
+		malformedJSON := `{"name": "Test", "priority": 1, "description": "Test desc"` // Missing closing brace
+		reqURL := fmt.Sprintf("%s/items/%d", ts.URL, initialItemModel.ID)
+		req, _ := http.NewRequest(http.MethodPut, reqURL, strings.NewReader(malformedJSON))
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		var errResp openapi.Error
+		err = json.NewDecoder(resp.Body).Decode(&errResp)
+		require.NoError(t, err)
+		assert.Contains(t, errResp.Error, "Invalid request payload")
+	})
+}
+
+func TestDeleteItemHandler(t *testing.T) { // Assuming this remains non-OpenAPI for now
+	db := setupHandlerTestDB(t)
+	defer db.Close()
+	initialItem := createTestItemDirectly(t, db, models.Item{Name: "ToDelete", Description: "Delete Desc", Priority: 1})
 	router := setupTestRouter(db)
 
-	reqPath := "/items/" + strconv.FormatInt(initialID, 10)
-	req, err := http.NewRequest(http.MethodDelete, reqPath, nil)
-	require.NoError(t, err)
+	reqPath := "/items/" + strconv.FormatInt(initialItem.ID, 10)
+	req, _ := http.NewRequest(http.MethodDelete, reqPath, nil)
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusNoContent, rr.Code)
-	_, err = database.GetItem(db, initialID)
+	_, err := database.GetItem(db, initialItem.ID)
 	assert.Error(t, err)
-	assert.Equal(t, sql.ErrNoRows, err, "Expected sql.ErrNoRows after deleting item")
+	assert.True(t, errors.Is(err, sql.ErrNoRows), "Expected sql.ErrNoRows after deleting item")
 }
 
-func TestCreateItemHandler_BadRequest(t *testing.T) {
-	db := setupHandlerTestDB(t)
-	defer db.Close()
-	router := setupTestRouter(db)
+// TestCreateItemHandler (old, non-OpenAPI one) is removed as POST /items is covered by TestCreateItemOpenAPI
+// TestUpdateItemHandler (old, non-OpenAPI one) is removed as PUT /items/{id} is covered by TestUpdateItemOpenAPI
 
-	t.Run("malformed json", func(t *testing.T) {
-		// Malformed: missing closing brace for name string, and overall closing brace
-		req, err := http.NewRequest(http.MethodPost, "/items", strings.NewReader("{\"name\": \"bad json value"))
-		require.NoError(t, err)
-		req.Header.Set("Content-Type", "application/json")
-		rr := httptest.NewRecorder()
-		router.ServeHTTP(rr, req)
-		assert.Equal(t, http.StatusBadRequest, rr.Code)
-		var errResp map[string]string
-		err = json.NewDecoder(rr.Body).Decode(&errResp)
-		require.NoError(t, err)
-		assert.Contains(t, errResp["error"], "Invalid request payload", "Expected 'Invalid request payload' for malformed JSON")
-	})
+// Test for GetItemByIdHandler is renamed to TestGetItemByIdOpenAPI and uses the OpenAPI router.
+// Test for CreateItemHandler is renamed to TestCreateItemOpenAPI and uses the OpenAPI router.
 
-	t.Run("missing required fields", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodPost, "/items", strings.NewReader("{\"description\": \"only description\"}"))
-		require.NoError(t, err)
-		req.Header.Set("Content-Type", "application/json")
-		rr := httptest.NewRecorder()
-		router.ServeHTTP(rr, req)
-		assert.Equal(t, http.StatusBadRequest, rr.Code)
-		var errResp map[string]string
-		err = json.NewDecoder(rr.Body).Decode(&errResp)
-		require.NoError(t, err)
-		// This test now hits the OpenAPI handler which has a more specific error message
-		// when only name is missing from a JSON that parses to openapi.NewItem.
-		// The openapi.NewItem struct has Name as a required field (non-pointer string),
-		// so if the JSON is `{"priority": 1}`, Name defaults to "".
-		// The handler then checks `if requestBody.Name == ""`
-		assert.Contains(t, errResp["error"], "Name is required", "Expected validation error for missing name via OpenAPI handler")
-	})
-}
+// TestCreateItemHandler_BadRequest is removed as its cases are now covered by TestCreateItemOpenAPI (missing name, malformed JSON)
+// or similar tests for TestUpdateItemOpenAPI.
+// The original TestCreateItemHandler_BadRequest had specific checks for "Invalid request payload" vs "Name is required".
+// The OpenAPI handlers have similar logic, so those specific cases are tested within TestCreateItemOpenAPI and TestUpdateItemOpenAPI.
+
+// Note: The old TestCreateItemHandler is removed because POST /items is now served by openapi_handlers.CreateItem.
+// Its functionality is tested in TestCreateItemOpenAPI.
+
+// Note: The old TestGetItemByIdHandler has been effectively replaced/updated by TestGetItemByIdOpenAPI
+// which uses the setupTestRouter that correctly routes GET /items/{id} to the openapi_handlers.GetItemById.
+
+// Note: The old TestCreateItemHandler_BadRequest has been removed. Its cases (malformed JSON, missing fields)
+// are covered by equivalent test cases within TestCreateItemOpenAPI and TestUpdateItemOpenAPI.
+// The new handlers provide similar error messages for these scenarios.

--- a/main.go
+++ b/main.go
@@ -68,7 +68,8 @@ func main() {
 	// })
 	// So, it will add "/items/{id}" to the router we pass.
 
-	// This will register GET /items/{id}
+	// This will register GET /items/{id}, POST /items, and PUT /items/{id}
+	// (because UpdateItemById is now part of ServerInterface and implemented by ItemAPIServer)
 	openapi.HandlerWithOptions(itemAPIServer, openapi.ChiServerOptions{
 		BaseRouter: router, // Register on our main router
 		// Middlewares: []openapi.MiddlewareFunc{}, // Optional: API specific middlewares
@@ -80,7 +81,7 @@ func main() {
 	// Note: The GetItemHandler was removed, so we don't register it here.
 	// The POST /items route is now handled by the OpenAPI generated code via HandlerWithOptions.
 	router.Get("/items", handlers.GetItemsHandler(DB)) // For getting all items
-	router.Put("/items/{id}", handlers.UpdateItemHandler(DB))
+	// router.Put("/items/{id}", handlers.UpdateItemHandler(DB)) // THIS LINE IS REMOVED
 	router.Delete("/items/{id}", handlers.DeleteItemHandler(DB))
 
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -72,6 +72,49 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+    put:
+      summary: Update an existing item
+      operationId: updateItemById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of the item to update
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        description: Item data to update
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateItem'
+      responses:
+        '200':
+          description: Item updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Item'
+        '400':
+          description: Invalid request payload or input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Item not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
 components:
   schemas:
@@ -85,6 +128,21 @@ components:
           type: string
         description:
           type: string
+          nullable: true
+        priority:
+          type: integer
+          format: int32
+    UpdateItem:
+      type: object
+      required:
+        - name
+        - priority
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+          nullable: true
         priority:
           type: integer
           format: int32
@@ -99,9 +157,10 @@ components:
           type: string
         description:
           type: string
+          nullable: true
         priority:
           type: integer
-          format: int32 # Assuming priority is int32, adjust if it's int64
+          format: int32
       required:
         - name
         - priority


### PR DESCRIPTION
This commit replaces the existing manual REST handler for updating items with an OpenAPI-driven implementation.

Changes include:

1.  **OpenAPI Specification (`openapi.yaml`):**
    *   Added a `PUT /items/{id}` operation definition.
    *   Introduced an `UpdateItem` schema for the request body.
    *   Made `description` fields nullable in `Item`, `NewItem`, and `UpdateItem` schemas for consistency.

2.  **Code Generation:**
    *   Regenerated OpenAPI server code (`internal/generated/openapi/item_api.gen.go`) using `oapi-codegen`. This updated the `ServerInterface` to include `UpdateItemById`.

3.  **Handler Implementation (`handlers/openapi_handlers.go`):**
    *   Implemented the `UpdateItemById` method on `ItemAPIServer`.
    *   This handler includes logic for request decoding, validation, database interaction (using `database.UpdateItem`), and generation of success/error responses according to the OpenAPI spec.
    *   Type conversions between `models.Item` and OpenAPI-generated types (`openapi.Item`, `openapi.UpdateItem`) are handled, particularly for `Priority` (int/int32) and `Description` (string/*string).

4.  **Main Application (`main.go`):**
    *   Removed the old `router.Put("/items/{id}", handlers.UpdateItemHandler(DB))` route.
    *   The `openapi.HandlerWithOptions` now correctly routes `PUT /items/{id}` requests to the new `ItemAPIServer.UpdateItemById` method.

5.  **Testing (`handlers/item_handlers_test.go`):**
    *   Removed the old `TestUpdateItemHandler`.
    *   Added a new test suite `TestUpdateItemOpenAPI` with comprehensive test cases for the `PUT /items/{id}` endpoint.
    *   Tests cover successful updates, item not found (404), invalid payloads (400 for missing name, invalid priority), invalid path parameters, and handling of nullable description fields.
    *   All tests pass, ensuring the new implementation functions as expected.