### PR TITLE
Remove 5etools-src submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "5etools-src"]
-	path = 5etools-src
-	url = https://github.com/5etools-mirror-3/5etools-src.git


### PR DESCRIPTION
Removes the `5etools-src` submodule from the repository. This involved removing the `.gitmodules` file (since it was the only submodule) and untracking the `5etools-src` directory.

---
*PR created automatically by Jules for task [3841491672701625096](https://jules.google.com/task/3841491672701625096) started by @kostadis*